### PR TITLE
✨ feat: add GAT562 mesh device variants and watch functionality

### DIFF
--- a/src/graphics/Screen.cpp
+++ b/src/graphics/Screen.cpp
@@ -1366,7 +1366,17 @@ int Screen::handleInputEvent(const InputEvent *event)
         // If no modules are using the input, move between frames
         if (!inputIntercepted) {
             if (event->inputEvent == INPUT_BROKER_LEFT || event->inputEvent == INPUT_BROKER_ALT_PRESS) {
+#if defined(GAT562_MESH_WATCH)
+                if (event->inputEvent == INPUT_BROKER_ALT_PRESS) {
+                    if (screenOn) {
+                        setOn(false);
+                    } else {
+                        setOn(true);
+                    }
+                }
+#else
                 showPrevFrame();
+#endif
             } else if (event->inputEvent == INPUT_BROKER_RIGHT || event->inputEvent == INPUT_BROKER_USER_PRESS) {
                 showNextFrame();
             } else if (event->inputEvent == INPUT_BROKER_SELECT) {

--- a/variants/nrf52840/gat562_mesh_trial_tracker/platformio.ini
+++ b/variants/nrf52840/gat562_mesh_trial_tracker/platformio.ini
@@ -1,16 +1,59 @@
-; The very slick RAK wireless RAK 4631 / 4630 board - Unified firmware for 5005/19003, with or without OLED RAK 1921
-[env:gat562_mesh_trial_tracker]
+; Base configuration for all GAT562 mesh devices
+[env:gat562_mesh_base]
 extends = nrf52840_base
-board_level = extra
 board = gat562_mesh_trial_tracker
 board_check = true
-build_flags = ${nrf52840_base.build_flags}
-  -I variants/nrf52840/gat562_mesh_trial_tracker
-  -D GAT562_MESH_TRIAL_TRACKER
-  -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
+build_flags = ${nrf52840_base.build_flags} -Ivariants/nrf52840/gat562_mesh_trial_tracker
   -DRADIOLIB_EXCLUDE_SX128X=1
   -DRADIOLIB_EXCLUDE_SX127X=1
   -DRADIOLIB_EXCLUDE_LR11X0=1
+  -DGAT562_MESH_TRIAL_TRACKER
 build_src_filter = ${nrf52_base.build_src_filter} +<../variants/nrf52840/gat562_mesh_trial_tracker>
 lib_deps =
   ${nrf52840_base.lib_deps}
+
+[env:gat562_mesh_trial_tracker]
+extends = env:gat562_mesh_base
+board_level = extra
+build_flags = ${env:gat562_mesh_base.build_flags} -DGAT562_MESH_TRIAL_TRACKER
+  -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
+  -DADC_MULTIPLIER=1.73
+
+[env:gat562_mesh_tracker_pro]
+extends = env:gat562_mesh_base
+build_flags = ${env:gat562_mesh_base.build_flags} -DGAT562_MESH_TRACKER_PRO
+  -DGPS_POWER_TOGGLE ; comment this line to disable triple press function on the user button to turn off gps entirely.
+  -DADC_MULTIPLIER=1.73
+  -DHAS_TRACKBALL=1 ; joystick
+  -DTB_UP=28      ; P0.28
+  -DTB_DOWN=4     ; P0.04
+  -DTB_LEFT=30    ; P0.30
+  -DTB_RIGHT=31   ; P0.31
+  -DTB_PRESS=26   ; P0.26 (SELECT)
+  -DTB_DIRECTION=FALLING
+
+[env:gat562_mesh_watch]
+extends = env:gat562_mesh_base
+board_level = extra
+build_unflags =
+  -DPIN_LED2
+  -DLED_CONN
+  -DLED_BLUE
+build_flags = ${env:gat562_mesh_base.build_flags} -DGAT562_MESH_WATCH
+  -DMESHTASTIC_EXCLUDE_GPS
+  -DADC_MULTIPLIER=1.75
+  -DPIN_VIBRATION=36
+  -DUSERPREFS_RINGTONE_NAG_SECS=9
+
+[env:gat562_mesh_evb_pro]
+extends = env:gat562_mesh_base
+board_level = extra
+build_flags = ${env:gat562_mesh_base.build_flags} -DGAT562_MESH_EVB_PRO
+  -DMESHTASTIC_EXCLUDE_SCREEN
+
+[env:gat562_mesh_solar_relay]
+extends = env:gat562_mesh_base
+board_level = extra
+build_flags = ${env:gat562_mesh_base.build_flags} -DGAT562_MESH_SOLAR_RELAY
+  -DMESHTASTIC_EXCLUDE_GPS
+  -DMESHTASTIC_EXCLUDE_SCREEN

--- a/variants/nrf52840/gat562_mesh_trial_tracker/variant.h
+++ b/variants/nrf52840/gat562_mesh_trial_tracker/variant.h
@@ -65,11 +65,15 @@ extern "C" {
  * Buttons
  */
 
-#define PIN_BUTTON1 9 // Pin for button on E-ink button module or IO expansion
+#if defined(GAT562_MESH_TRACKER_PRO)
+#define CANCEL_BUTTON_PIN 9
 #define BUTTON_NEED_PULLUP
-#define PIN_BUTTON2 10
-#define PIN_BUTTON3 24
-#define PIN_BUTTON4 25
+#define CANCEL_BUTTON_ACTIVE_LOW true
+#define CANCEL_BUTTON_ACTIVE_PULLUP false
+#else
+#define PIN_BUTTON1 9
+#define BUTTON_NEED_PULLUP
+#endif
 
 /*
  * Analog pins

--- a/variants/nrf52840/gat562_mesh_trial_tracker/variant.h
+++ b/variants/nrf52840/gat562_mesh_trial_tracker/variant.h
@@ -19,6 +19,11 @@
 #ifndef _VARIANT_GAT562_MESH_TRIAL_TRACKER_
 #define _VARIANT_GAT562_MESH_TRIAL_TRACKER_
 
+#ifndef GAT562_MESH_TRIAL_TRACKER
+#define GAT562_MESH_TRIAL_TRACKER
+#endif
+
+
 // led pin 2 (blue), see https://github.com/meshtastic/firmware/blob/master/src/mesh/NodeDB.cpp#L723
 #define RAK4630
 
@@ -62,7 +67,7 @@ extern "C" {
 
 #define PIN_BUTTON1 9 // Pin for button on E-ink button module or IO expansion
 #define BUTTON_NEED_PULLUP
-#define PIN_BUTTON2 12
+#define PIN_BUTTON2 10
 #define PIN_BUTTON3 24
 #define PIN_BUTTON4 25
 
@@ -160,7 +165,7 @@ static const uint8_t SCK = PIN_SPI_SCK;
 #define PIN_QSPI_IO3 2
 
 // On-board QSPI Flash
-#define EXTERNAL_FLASH_DEVICES IS25LP080D
+#define EXTERNAL_FLASH_DEVICES W25Q16JV_IQ
 #define EXTERNAL_FLASH_USE_QSPI
 
 /* @note RAK5005-O GPIO mapping to RAK4631 GPIO ports
@@ -237,6 +242,8 @@ SO GPIO 39/TXEN MAY NOT BE DEFINED FOR SUCCESSFUL OPERATION OF THE SX1262 - TG
 // Power is on the controllable 3V3_S rail
 // #define PIN_GPS_RESET (34)
 // #define PIN_GPS_EN PIN_3V3_EN
+#define PIN_GPS_EN PIN_3V3_EN // P1.02, (32 + 2)
+
 #define PIN_GPS_PPS (17) // Pulse per second input from the GPS
 
 #define GPS_BAUDRATE 9600
@@ -262,7 +269,6 @@ SO GPIO 39/TXEN MAY NOT BE DEFINED FOR SUCCESSFUL OPERATION OF THE SX1262 - TG
 #undef AREF_VOLTAGE
 #define AREF_VOLTAGE 3.0
 #define VBAT_AR_INTERNAL AR_INTERNAL_3_0
-#define ADC_MULTIPLIER 1.73
 
 // #define HAS_RTC 1
 


### PR DESCRIPTION
- Add base configuration for GAT562 mesh devices in platformio.ini
- Add support for multiple GAT562 variants (tracker_pro, watch, evb_pro, solar_relay)
- Implement conditional screen toggle behavior for GAT562 mesh watch
- Update hardware configuration (button pins, flash device, GPS enable)
- Refactor configuration to use inheritance for better maintainability